### PR TITLE
Remove reference to Bignum

### DIFF
--- a/lib/mathn.rb
+++ b/lib/mathn.rb
@@ -68,7 +68,7 @@ class Integer
   remove_method :/
 
   ##
-  # +/+ defines the Rational division for Bignum.
+  # +/+ defines the Rational division for Integer.
   #
   #   (2**72) / ((2**70) * 3)  # => 4/3
 


### PR DESCRIPTION
`Fixnum` and `Bignum` were rationalised into `Integer`, since ruby version 2.4.0