### PR TITLE
Add Ruby 2.5 to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.5
   - ruby-head
 before_install: gem install bundler


### PR DESCRIPTION
As I checked this gem `mathn` does not work on Ruby 2.3, 2.2, 2.1 and 2.0, I want to add stable Ruby 2.5 to Travis CI, just in case for the future.

https://travis-ci.org/sass/ruby-sass/builds/386541140

```
/home/travis/build/sass/ruby-sass/vendor/bundle/ruby/2.3.0/gems/mathn-0.1.0/lib/mathn.rb:68:in `remove_method': method `/' not defined in Integer (NameError)
```

