### PR TITLE
Add missing dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ sudo: false
 language: ruby
 rvm:
   - 2.5
+  - 2.7
   - ruby-head
 before_install: gem install bundler

--- a/mathn.gemspec
+++ b/mathn.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "cmath"
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rake-compiler"

--- a/test/test_mathn.rb
+++ b/test/test_mathn.rb
@@ -19,7 +19,7 @@ class TestMathn < Test::Unit::TestCase
   end
 
   def test_floor
-    assert_separately(%w[-rmathn], <<-EOS, ignore_stderr: true)
+    assert_separately(%w[-rbundler/setup -rmathn], <<-EOS, ignore_stderr: true)
       assert_equal( 2, ( 13/5).floor)
       assert_equal( 2, (  5/2).floor)
       assert_equal( 2, ( 12/5).floor)
@@ -44,7 +44,7 @@ class TestMathn < Test::Unit::TestCase
   end
 
   def test_ceil
-    assert_separately(%w[-rmathn], <<-EOS, ignore_stderr: true)
+    assert_separately(%w[-rbundler/setup -rmathn], <<-EOS, ignore_stderr: true)
       assert_equal( 3, ( 13/5).ceil)
       assert_equal( 3, (  5/2).ceil)
       assert_equal( 3, ( 12/5).ceil)
@@ -69,7 +69,7 @@ class TestMathn < Test::Unit::TestCase
   end
 
   def test_truncate
-    assert_separately(%w[-rmathn], <<-EOS, ignore_stderr: true)
+    assert_separately(%w[-rbundler/setup -Ilib -rmathn], <<-EOS, ignore_stderr: true)
       assert_equal( 2, ( 13/5).truncate)
       assert_equal( 2, (  5/2).truncate)
       assert_equal( 2, ( 12/5).truncate)
@@ -94,7 +94,7 @@ class TestMathn < Test::Unit::TestCase
   end
 
   def test_round
-    assert_separately(%w[-rmathn], <<-EOS, ignore_stderr: true)
+    assert_separately(%w[-rbundler/setup -rmathn], <<-EOS, ignore_stderr: true)
       assert_equal( 3, ( 13/5).round)
       assert_equal( 3, (  5/2).round)
       assert_equal( 2, ( 12/5).round)
@@ -182,7 +182,7 @@ class TestMathn < Test::Unit::TestCase
   end
 
   def test_rational
-    assert_separately(%w[-rmathn], "#{<<-"begin;"}\n#{<<-"end;"}", ignore_stderr: true)
+    assert_separately(%w[-rbundler/setup -rmathn], "#{<<-"begin;"}\n#{<<-"end;"}", ignore_stderr: true)
     begin;
       assert_equal(-5, "-5".to_r)
       assert_equal(1, "5/5".to_r)


### PR DESCRIPTION
This gem is deprecated since it was extracted out of ruby-core, but the extraction was done incorrectly, so it currently doesn't even work on ruby 2.7.

The issue is that the gem depends on the `cmath` library, but it's not listed as a dependency, so when the gem is installed, `cmath` is not installed, and using it fails like this:

```
$ gem install mathn
Fetching mathn-0.1.0.gem
Building native extensions. This could take a while...
Successfully installed mathn-0.1.0
1 gem installed
(add_missing_dependency) deivid@chaba ~/Code/ruby/mathn $ ruby -rmathn -e'puts 0'
Traceback (most recent call last):
	1: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:88:in `require'
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:88:in `require': cannot load such file -- mathn (LoadError)
	5: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:152:in `require'
	4: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:164:in `rescue in require'
	3: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:164:in `require'
	2: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/mathn-0.1.0/lib/mathn.rb:45:in `<top (required)>'
	1: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:88:in `require'
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:88:in `require': cannot load such file -- cmath.rb (LoadError)
```

This PR fixes the issue.