### PR TITLE
Migrate set-output to $GITHUB_OUTPUT #17

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,7 +20,7 @@ jobs:
       id: package
       run: |
         SOURCE_DATE_EPOCH=`git log -1 --format=%ct` rake build
-        set pkg/*.gem && echo "::set-output name=gem::${1#*/}"
+        set pkg/*.gem && echo "gem=${1#*/}" >> $GITHUB_OUTPUT
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/